### PR TITLE
Update build process, Chakra invocation, and config file locations to avoid user confusion

### DIFF
--- a/getting-started/argument-network-config.md
+++ b/getting-started/argument-network-config.md
@@ -9,7 +9,7 @@
 Example network configurations can be found at
 
 :::{code-block} console
-$ ${ASTRA_SIM}/inputs/network/analytical/
+$ ${ASTRA_SIM}/examples/network_analytical/network.yml
 :::
 
 - **topology-name**: (string) put "Hierarchical"
@@ -44,11 +44,6 @@ Each configurations below is represented as an array of size **dimensions-count*
 
 ## [Garnet Network Config](https://github.com/astra-sim/astra-network-garnet/tree/c09ba4ebee0643cff3f75d64143d5310b7f31ee1)
 
-Example network configurations can be found at
-
-:::{code-block} console
-$ ${ASTRA_SIM}/inputs/network/garnet/
-:::
 
 - **num-npus**: (int) Total number of NPUs we are simulating
 
@@ -128,7 +123,7 @@ In addition to the ns3 configurations (including the physical topology), the bin
 Examples of this can be found at 
 
 :::{code-block} console
-$ ${ASTRA_SIM}/inputs/network/ns3
+$ ${ASTRA_SIM}/examples/ns3/sample_64nodes_2D.json
 :::
 
 This file defines the *logical* topology, where each number corresponds to the number of NPUs in a dimension.

--- a/getting-started/argument-remote-memory-config.md
+++ b/getting-started/argument-remote-memory-config.md
@@ -9,7 +9,7 @@
 Example remote memory configurations can be found at
 
 :::{code-block} console
-$ ${ASTRA_SIM}/inputs/remote_memory/analytical
+$ ${ASTRA_SIM}/examples/network_analytical/remote_memory.json
 :::
 
 - **memory-type**: (string) memory type ("NO_MEMORY_EXPANSION", "PER_NODE_MEMORY_EXPANSION", "PER_NPU_MEMORY_EXPANSION", or "MEMORY_POOL")

--- a/getting-started/argument-system-config.md
+++ b/getting-started/argument-system-config.md
@@ -7,7 +7,7 @@
 Example system configurations can be found at:
 
 :::{code-block} console
-$ ${ASTRA_SIM}/inputs/system/
+$ ${ASTRA_SIM}/examples/network_analytical/system.json
 :::
 
 - **scheduling-policy**: (LIFO/FIFO)

--- a/getting-started/argument-workload-config.md
+++ b/getting-started/argument-workload-config.md
@@ -6,7 +6,7 @@
 
 The example traces can be found at:
 :::{code-block} console
-${ASTRA_SIM}/inputs/workload/
+${ASTRA_SIM}/examples/network_analytical/workload
 :::
 
 :::{note}
@@ -16,6 +16,24 @@ The naming rule for execution traces follows the format {path_prefix}.{npu_id}.e
 ## Using [Chakra Execution Trace](https://github.com/mlcommons/chakra/wiki)
 ASTRA-sim supports Chakra ET (Execution Trace) as inputs to the workload layer. 
 
+To run a preset workload, such as `AllReduce_1MB`, execute the following commands:
+```bash
+cd ${ASTRA_SIM}/examples/network_analytical
+bash run_network_analytical.sh
+```
+
+This script will compile ASTRA-Sim, run the workload on an 8-NPU cluster, and display the number of cycles required to complete the simulation.
+```bash
+[2025-01-26 23:03:37.384] [workload] [info] sys[0] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[1] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[2] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[3] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[4] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[5] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[6] finished, 64440 cycles, exposed communication 64440 cycles.
+[2025-01-26 23:03:37.384] [workload] [info] sys[7] finished, 64440 cycles, exposed communication 64440 cycles.
+```
+
 An example of how to generate Chakra traces and run ASTRA-sim is illustrated at [Running Simulation with Chakra](https://github.com/mlcommons/chakra/wiki/Running-Simulation-with-Chakra). 
 
 ## Using Execution Trace Converter (et_converter)
@@ -23,32 +41,33 @@ You can convert ASTRA-sim 1.0 text input files into Chakra traces with the follo
 ```bash
 $ cd ./extern/graph_frontend/chakra/
 $ pip3 install .
-$ python3 -m chakra.et_converter.et_converter \
-    --input_type Text \
-    --input_filename ../../../inputs/workload/ASTRA-sim-1.0/Resnet50_DataParallel.txt \
-    --output_filename ../../../inputs/workload/ASTRA-sim-2.0/Resnet50_DataParallel \
-    --num_npus 64 \
-    --num_dims 1 \
-    --num_passes 1
+$ pip3 install --upgrade protobuf
+$ chakra_converter Text \
+    --input ../../../examples/text_converter/text_workloads/Resnet50_DataParallel.txt \
+    --output ../../../examples/text_converter/text_workloads/Resnet50_DataParallel \
+    --num-npus 8 \
+    --num-passes 1
 ```
 
-Run the following command.
+In the project root, run the following command.
 ```bash
-$ cd -
 $ ./build/astra_analytical/build/bin/AstraSim_Analytical_Congestion_Unaware \
-  --workload-configuration=./inputs/workload/ASTRA-sim-2.0/Resnet50_DataParallel \
-  --system-configuration=./inputs/system/Switch.json \
-  --network-configuration=./inputs/network/analytical/Switch.yml \
-  --remote-memory-configuration=./inputs/remote_memory/analytical/no_memory_expansion.json
+  --workload-configuration=./examples/text_converter/text_workloads/Resnet50_DataParallel \
+  --system-configuration=./examples/text_converter/system.json \
+  --network-configuration=./examples/text_converter/network.yml \
+  --remote-memory-configuration=./examples/text_converter/remote_memory.json
 ```
 
 Upon completion, ASTRA-sim will display the number of cycles it took to run the simulation.
 ```bash
-sys[62] finished, 6749042 cycles
-sys[61] finished, 6749042 cycles
-...
-sys[0] finished, 6749042 cycles
-sys[63] finished, 6749042 cycles
+[2025-01-26 22:50:05.669] [workload] [info] sys[0] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[1] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[2] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[3] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[4] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[5] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[6] finished, 1082478600 cycles, exposed communication 28600 cycles.
+[2025-01-26 22:50:05.669] [workload] [info] sys[7] finished, 1082478600 cycles, exposed communication 28600 cycles.
 ```
 
 ## Enable Communicator Groups

--- a/getting-started/argument-workload-config.md
+++ b/getting-started/argument-workload-config.md
@@ -41,7 +41,6 @@ You can convert ASTRA-sim 1.0 text input files into Chakra traces with the follo
 ```bash
 $ cd ./extern/graph_frontend/chakra/
 $ pip3 install .
-$ pip3 install --upgrade protobuf
 $ chakra_converter Text \
     --input ../../../examples/text_converter/text_workloads/Resnet50_DataParallel.txt \
     --output ../../../examples/text_converter/text_workloads/Resnet50_DataParallel \

--- a/getting-started/build.md
+++ b/getting-started/build.md
@@ -7,7 +7,7 @@ Please make sure that you have all the required depencencies installed.
 ## Clone Repository
 
 :::{code-block} console
-git clone --recurse-submodules git@github.com:astra-sim/astra-sim.git
+git clone git@github.com:astra-sim/astra-sim.git
 ASTRA_SIM=$(realpath ./astra-sim)
 :::
 
@@ -15,6 +15,7 @@ ASTRA_SIM=$(realpath ./astra-sim)
 
 :::{code-block} console
 cd ${ASTRA_SIM}
+git submodule update --init --recursive # setup submodules
 ::: 
 
 ### Analytical Network Backend

--- a/getting-started/build.md
+++ b/getting-started/build.md
@@ -9,14 +9,11 @@ Please make sure that you have all the required depencencies installed.
 :::{code-block} console
 git clone git@github.com:astra-sim/astra-sim.git
 ASTRA_SIM=$(realpath ./astra-sim)
+cd ${ASTRA_SIM}
+git submodule update --init --recursive
 :::
 
 ## Compile Program
-
-:::{code-block} console
-cd ${ASTRA_SIM}
-git submodule update --init --recursive
-::: 
 
 ### Analytical Network Backend
 :::{code-block} console

--- a/getting-started/build.md
+++ b/getting-started/build.md
@@ -15,7 +15,7 @@ ASTRA_SIM=$(realpath ./astra-sim)
 
 :::{code-block} console
 cd ${ASTRA_SIM}
-git submodule update --init --recursive # setup submodules
+git submodule update --init --recursive
 ::: 
 
 ### Analytical Network Backend


### PR DESCRIPTION
- Added a command to explicitly pull submodules during the build process to avoid confusion, as seen in https://github.com/astra-sim/astra-sim/issues/286
- Updated the Chakra invocation method from `python3 -m chakra.et_converter.et_converter` to a standalone binary command, such as `chakra_converter PyTorch --input input.json --output output`. Updated corresponding commands to avoid confusion, as seen in https://github.com/astra-sim/astra-sim/issues/286 
- Moved configuration files (`network`, `workload`, `system`) from the `inputs` folder to the `examples` folder. Updated relevant documentation to reflect this change, addressing confusion seen in https://github.com/astra-sim/astra-sim/issues/286 and https://github.com/astra-sim/astra-sim/issues/284