### PR TITLE
Fix typo in build script filename

### DIFF
--- a/_scripts/build_current_doc.sh
+++ b/_scripts/build_current_doc.sh
@@ -7,6 +7,6 @@ rm -rf ./_build
 # Compile the latest version
 sphinx-build \
     -b html \
-    -j$(nproc) \
+    -j $(nprocs) \
     -d ./_build/doctree \
     . ./_build/html


### PR DESCRIPTION
Fix from `build_corrent_docs.sh` to `build_current_docs.sh`