### PR TITLE
Update Commgroup documentation

### DIFF
--- a/getting-started/argument-comm-group-config.md
+++ b/getting-started/argument-comm-group-config.md
@@ -1,0 +1,48 @@
+# Argument {COMM_GROUP_CONFIG}
+
+ASTRA-sim 2.0 supports [communicator groups](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html).
+You can pass a communicator group configuration file by specifying the file path using `--comm-group-configuration`.
+If you do not pass a communicator group configuration file, by default, it will create a single group with all GPUs.
+A valid communication group file is a JSON file with the following format.
+```
+{
+  "<communicator_group_id>" : [gpu_ids]
+}
+```
+For example, you can create two communicator groups with the following configuration file.
+The first communicator group, with ID 0, includes GPU IDs from 0 to 3. The second communicator group, with ID 1, includes GPU IDs from 4 to 7.
+```
+{
+  "0": [0, 1, 2, 3],
+  "1": [4, 5, 6, 7]
+}
+```
+
+When simulating the workload, ASTRA-sim looks for the communication group id in each communication ET node (i.e. different operators of the same rank may have different communicator group). ASTRA-sim will look for the attribute `pg_name` in the communication ET node. 
+
+The following is *part* of a Chakra ET. 
+```json
+{
+  "id": "4",
+  "name": "in_emb_y@0_X1COMM",
+  "type": "COMM_COLL_NODE",
+  "attr": [
+    {
+      "name": "comm_size",
+      "int64Val": "26843545600"
+    },
+    {
+      "name": "comm_type",
+      "int64Val": "2"
+    },
+    {
+      "name": "pg_name",
+      "stringVal": "17"
+    },
+    {
+      "name": "is_cpu_op",
+      "int32Val": 0
+    }
+  ]
+}
+```

--- a/getting-started/argument-workload-config.md
+++ b/getting-started/argument-workload-config.md
@@ -68,22 +68,3 @@ Upon completion, ASTRA-sim will display the number of cycles it took to run the 
 [2025-01-26 22:50:05.669] [workload] [info] sys[6] finished, 1082478600 cycles, exposed communication 28600 cycles.
 [2025-01-26 22:50:05.669] [workload] [info] sys[7] finished, 1082478600 cycles, exposed communication 28600 cycles.
 ```
-
-## Enable Communicator Groups
-ASTRA-sim 2.0 supports [communicator groups](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html).
-You can pass a communicator group configuration file by specifying the file path using `--comm-group-configuration`.
-If you do not pass a communicator group configuration file, by default, it will create a single group with all GPUs.
-A valid communication group file is a JSON file with the following format.
-```
-{
-  "<communicator_group_id>" : [gpu_ids]
-}
-```
-For example, you can create two communicator groups with the following configuration file.
-The first communicator group, with ID 0, includes GPU IDs from 0 to 3. The second communicator group, with ID 1, includes GPU IDs from 4 to 7.
-```
-{
-  "0": [0, 1, 2, 3],
-  "1": [4, 5, 6, 7]
-}
-```

--- a/getting-started/run.md
+++ b/getting-started/run.md
@@ -7,7 +7,8 @@ ${ASTRA_SIM_BIN} \
   --workload-configuration=${WORKLOAD_CONFIG} \
   --system-configuration=${SYSTEM_CONFIG} \
   --network-configuration=${NETWORK_CONFIG} \
-  --remote-memory-configuration=${REMOTE_MEMORY_CONFIG}
+  --remote-memory-configuration=${REMOTE_MEMORY_CONFIG} \
+  --comm-group-configuration=${COMM_GROUP_CONFIG}
 :::
 
 :::{toctree}
@@ -15,6 +16,7 @@ argument-workload-config.md
 argument-system-config.md
 argument-network-config.md
 argument-remote-memory-config.md
+argument-comm-group-config.md
 :::
 
 :::{note}


### PR DESCRIPTION
1. Split Commgroup related documentation to its own page
2. Include examples of how Commgroup is encoded in Chakra ET node